### PR TITLE
Add type annotations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,10 @@
 .idea
+.mypy_cache
 .DS_Store
 *.pyc
 venv
+.venv
 dist
 build
 *.egg-info
+__pycache__

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+type-check:
+	mypy .

--- a/inngest/client.py
+++ b/inngest/client.py
@@ -1,19 +1,27 @@
 import json
 from datetime import datetime
 import requests
+from typing import Optional
 
 from inngest.exceptions import InngestException
 
 
 class Event:
-  def __init__(self, name=None, data=None, user=None, version=None, timestamp=None):
+  def __init__(
+    self,
+    name: Optional[str] = None,
+    data: Optional[dict] = None,
+    user: Optional[dict] = None,
+    version: Optional[str] = None,
+    timestamp: Optional[int] = None,
+  ) -> None:
     self.name = name
     self.data = data
     self.user = user
     self.version = version
     self.timestamp = timestamp if timestamp else int(datetime.now().timestamp() * 1000)
 
-  def payload(self):
+  def payload(self) -> dict:
     data = {
       'name': self.name,
       'data': self.data,
@@ -31,12 +39,16 @@ class InngestClient:
     'User-Agent': 'inngest-python-sdk/1.0.0',
   }
 
-  def __init__(self, inngest_key=None, endpoint=API_ENDPOINT):
+  def __init__(
+    self,
+    inngest_key: str,
+    endpoint: str = API_ENDPOINT,
+  ) -> None:
     self.inngest_key = inngest_key
     self.endpoint = endpoint
     self.session = requests.session()
 
-  def send(self, event):
+  def send(self, event: Event) -> requests.Response:
     validate_event(event)
     validate_inngest_key(self.inngest_key)
 
@@ -51,7 +63,7 @@ class InngestClient:
     )
 
 
-def validate_event(event):
+def validate_event(event: Event) -> None:
   if not event:
     raise InngestException("Event can't be `None`")
 
@@ -67,6 +79,6 @@ def validate_event(event):
     raise InngestException("Could not serialize data into json")
 
 
-def validate_inngest_key(inngest_key):
+def validate_inngest_key(inngest_key: str) -> None:
   if not inngest_key:
     raise InngestException("Inngest key was not specified")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[tool.mypy]
+disallow_incomplete_defs = true
+disallow_untyped_calls = true
+disallow_untyped_defs = true
+warn_redundant_casts = true
+warn_unreachable = true
+warn_unused_ignores = true

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+mypy==0.991
+types-requests==2.28.11.8
+types-setuptools==65.7.0.3


### PR DESCRIPTION
# Changes

- Add type annotations.
- Add `requirements-dev.txt`, which includes dev dependencies for type checking.
- Add `pyproject.toml` for configuring Mypy.
- Add `Makefile` with a task for type-checking.
- Add some entries to `.gitignore`. Added `.venv` even though `venv` already exists because `.venv` is the default virtual environment directory name for some tools (e.g. Pipenv).

# Motivation

Type-checking is super sweet

# Testing

Mypy passes:

```
$ make type-check
mypy .
Success: no issues found in 4 source files
```

But type-checking should be added to CI to prevent regressions